### PR TITLE
Can now pass in the top level observatory, and skeleton support for RHESSI

### DIFF
--- a/idl/gen/hv_copy2outgoing.pro
+++ b/idl/gen/hv_copy2outgoing.pro
@@ -2,14 +2,14 @@
 ; Copy a set of given list of files to the outgoing directory
 ;
 ;
-PRO HV_COPY2OUTGOING,files,search = search,delete_original = delete_original
+PRO HV_COPY2OUTGOING,files,write_this,search = search,delete_original = delete_original
   progname = 'hv_copy2outgoing'
 ;
   g = HVS_GEN()
 ;
 ; get the outgoing directory for this nickname
 ;
-  storage = HV_STORAGE(nickname = 'dummy')
+  storage = HV_STORAGE(write_this, nickname = 'dummy')
   outgoing_root = storage.outgoing
 ;
 ; Operating system

--- a/idl/gen/hv_db.pro
+++ b/idl/gen/hv_db.pro
@@ -6,7 +6,7 @@
 ;              sophisticated approach using Dominic Zarro's/ Ron
 ;              Yurow's database system as developed for EIS 
 ;-
-PRO HV_DB,hvs,check_fitsname_only = check_fitsname_only,$
+PRO HV_DB,hvsi,check_fitsname_only = check_fitsname_only,$
           already_written = already_written,$
           update = update
 ;
@@ -19,9 +19,9 @@ PRO HV_DB,hvs,check_fitsname_only = check_fitsname_only,$
 ; Get the location and the filename for the database for the
 ; given YYYY/MM/DD __ nickname __ measurement
 ;
-  storage = HV_STORAGE(nickname = hvs.details.nickname)
-  dbloc = HV_WRITE_LIST_JP2_MKDIR(hvs,storage.db_location)
-  dbname = HV_DBNAME_CONVENTION(hvs,/create)
+  storage = HV_STORAGE(hvsi.write_this, nickname = hvsi.details.nickname)
+  dbloc = HV_WRITE_LIST_JP2_MKDIR(hvsi,storage.db_location)
+  dbname = HV_DBNAME_CONVENTION(hvsi,/create)
 ;
 ; Check if the FITS name is already in the data base
 ;
@@ -29,7 +29,7 @@ PRO HV_DB,hvs,check_fitsname_only = check_fitsname_only,$
      dbfile = dbloc + dbname
      if file_exist(dbfile) then begin
         db = rd_tfile(dbloc + dbname,4,1,delim = delim)
-        in_db_index = where( db[1,*] eq hvs.fitsname, indb )
+        in_db_index = where( db[1,*] eq hvsi.fitsname, indb )
         IF indb gt 0 then begin
            already_written = 1 
         endif else begin 
@@ -38,24 +38,24 @@ PRO HV_DB,hvs,check_fitsname_only = check_fitsname_only,$
      endif else begin
         already_written = 0
      endelse
-     print,progname + ': checked FITS filename only; '+ hvs.fitsname +' in db; '+ dbloc + dbname + '.'
+     print,progname + ': checked FITS filename only; '+ hvsi.fitsname +' in db; '+ dbloc + dbname + '.'
      print,progname + ': result = '+ trim(already_written)
   ENDIF ELSE BEGIN
-     jp2loc = HV_WRITE_LIST_JP2_MKDIR(hvs,storage.jp2_location,/return_path_only)
-     jp2name = HV_FILENAME_CONVENTION(hvs,/create)
+     jp2loc = HV_WRITE_LIST_JP2_MKDIR(hvsi,storage.jp2_location,/return_path_only)
+     jp2name = HV_FILENAME_CONVENTION(hvsi,/create)
 ;
 ; Create the comma separated entry
 ;
-     dbtext = hvs.dir + delim + $
-              hvs.fitsname + delim + $
+     dbtext = hvsi.dir + delim + $
+              hvsi.fitsname + delim + $
               jp2loc + delim + $
               jp2name + delim + $
               systime(0) + delim
 ;
 ; Add in other information, if required.
 ;
-     if tag_exist(hvs.details,'called_by') then begin
-        dbtext = dbtext + hvs.details.called_by + delim
+     if tag_exist(hvsi.details,'called_by') then begin
+        dbtext = dbtext + hvsi.details.called_by + delim
      endif
 ;
 ; Message if a new database entry is being created
@@ -66,7 +66,7 @@ PRO HV_DB,hvs,check_fitsname_only = check_fitsname_only,$
         HV_WRT_ASCII,'This file first created ' + systime(0),dbloc + dbname,/append
         HV_WRT_ASCII,'fitsdir,fitsname,jp2dir,jp2name,time_of_writing,calling_program[optional],',dbloc + dbname,/append
      endif else begin
-        HV_DB,hvs,/check_fitsname_only,already_written = already_written
+        HV_DB,hvsi,/check_fitsname_only,already_written = already_written
      endelse
 ;
 ; Update the database and the latest file

--- a/idl/gen/hv_dbname_convention.pro
+++ b/idl/gen/hv_dbname_convention.pro
@@ -4,31 +4,32 @@
 ; Function to create a JP2 file name from its source HVS file, and to
 ; split up an input filename into its component parts
 ;
-FUNCTION HV_DBNAME_CONVENTION, hvs, create = create
+FUNCTION HV_DBNAME_CONVENTION, hvsi, create = create
 ;
 ; Take the HVS header and create a db filename
 ;
-  NotGiven = (HV_STORAGE(nickname = hvs.details.nickname)).NotGiven
+  print, HV_STORAGE(hvsi.write_this, nickname = hvsi.details.nickname)
+  NotGiven = (HV_STORAGE(hvsi.write_this, nickname = hvsi.details.nickname)).NotGiven
   if keyword_set(create) then begin
-     if not(is_struct(hvs)) then begin
+     if not(is_struct(hvsi)) then begin
         print,' Input is not a structure.  Returning -1 '
         answer = -1
      endif else begin
 ;
 ; Date
 ;
-        if tag_exist(hvs,'yy') then begin
-           if hvs.yy eq '' then yy = NotGiven else yy = hvs.yy
+        if tag_exist(hvsi,'yy') then begin
+           if hvsi.yy eq '' then yy = NotGiven else yy = hvsi.yy
         endif else begin
            yy = NotGiven
         endelse
-        if tag_exist(hvs,'mm') then begin
-           if hvs.mm eq '' then mm = NotGiven else mm = hvs.mm
+        if tag_exist(hvsi,'mm') then begin
+           if hvsi.mm eq '' then mm = NotGiven else mm = hvsi.mm
         endif else begin
            mm = NotGiven
         endelse
-        if tag_exist(hvs,'dd') then begin
-           if hvs.dd eq '' then dd = NotGiven else dd = hvs.dd
+        if tag_exist(hvsi,'dd') then begin
+           if hvsi.dd eq '' then dd = NotGiven else dd = hvsi.dd
         endif else begin
            dd = NotGiven
         endelse
@@ -36,15 +37,15 @@ FUNCTION HV_DBNAME_CONVENTION, hvs, create = create
 ;
 ; Nickname + measurement
 ;
-        details = hvs.details
+        details = hvsi.details
         if tag_exist(details,'nickname') then begin
            if details.nickname eq '' then nickname = NotGiven else nickname = details.nickname
         endif else begin
            nickname = NotGiven
         endelse
 
-        if tag_exist(hvs,'measurement') then begin
-           if hvs.measurement eq '' then measurement = NotGiven else measurement = hvs.measurement
+        if tag_exist(hvsi,'measurement') then begin
+           if hvsi.measurement eq '' then measurement = NotGiven else measurement = hvsi.measurement
         endif else begin
            measurement = NotGiven
         endelse

--- a/idl/gen/hv_filename_convention.pro
+++ b/idl/gen/hv_filename_convention.pro
@@ -4,57 +4,58 @@
 ; Function to create a JP2 file name from its source HVS file, and to
 ; split up an input filename into its component parts
 ;
-FUNCTION HV_FILENAME_CONVENTION, hvs, create = create, split = split, construct = construct
+FUNCTION HV_FILENAME_CONVENTION, hvsi, create = create, split = split, construct = construct
 ;
 ; Take the HVS header and create a filename
 ;
-  NotGiven = (HV_STORAGE(nickname = hvs.details.nickname)).NotGiven
+  hv_storage_information = HV_STORAGE(hvsi.write_this, nickname = hvsi.details.nickname)
+  NotGiven = hv_storage_information.NotGiven
   if keyword_set(create) then begin
-     if not(is_struct(hvs)) then begin
+     if not(is_struct(hvsi)) then begin
         print,' Input is not a structure.  Returning -1 '
         answer = -1
      endif else begin
 
-        if tag_exist(hvs,'yy') then begin
-           if hvs.yy eq '' then yy = NotGiven else yy = hvs.yy
+        if tag_exist(hvsi,'yy') then begin
+           if hvsi.yy eq '' then yy = NotGiven else yy = hvsi.yy
         endif else begin
            yy = NotGiven
         endelse
-        if tag_exist(hvs,'mm') then begin
-           if hvs.mm eq '' then mm = NotGiven else mm = hvs.mm
+        if tag_exist(hvsi,'mm') then begin
+           if hvsi.mm eq '' then mm = NotGiven else mm = hvsi.mm
         endif else begin
            mm = NotGiven
         endelse
-        if tag_exist(hvs,'dd') then begin
-           if hvs.dd eq '' then dd = NotGiven else dd = hvs.dd
+        if tag_exist(hvsi,'dd') then begin
+           if hvsi.dd eq '' then dd = NotGiven else dd = hvsi.dd
         endif else begin
            dd = NotGiven
         endelse
         date = yy + '_' +  mm + '_' +  dd
 
-        if tag_exist(hvs,'hh') then begin
-           if hvs.hh eq '' then hh = NotGiven else hh = hvs.hh
+        if tag_exist(hvsi,'hh') then begin
+           if hvsi.hh eq '' then hh = NotGiven else hh = hvsi.hh
         endif else begin
            hh = NotGiven
         endelse
-        if tag_exist(hvs,'mmm') then begin
-           if hvs.mmm eq '' then mmm = NotGiven else mmm = hvs.mmm
+        if tag_exist(hvsi,'mmm') then begin
+           if hvsi.mmm eq '' then mmm = NotGiven else mmm = hvsi.mmm
         endif else begin
            mmm = NotGiven
         endelse
-        if tag_exist(hvs,'ss') then begin
-           if hvs.ss eq '' then ss = NotGiven else ss = hvs.ss
+        if tag_exist(hvsi,'ss') then begin
+           if hvsi.ss eq '' then ss = NotGiven else ss = hvsi.ss
         endif else begin
            ss = NotGiven
         endelse
-        if tag_exist(hvs,'milli') then begin
-           if hvs.milli eq '' then milli = NotGiven else milli = hvs.milli
+        if tag_exist(hvsi,'milli') then begin
+           if hvsi.milli eq '' then milli = NotGiven else milli = hvsi.milli
         endif else begin
            milli = NotGiven
         endelse
         time =  hh + '_' +  mmm + '_' +   ss + '_' +  milli
 
-        details = hvs.details
+        details = hvsi.details
         if tag_exist(details,'observatory') then begin
            if details.observatory eq '' then observatory = NotGiven else observatory = details.observatory
         endif else begin
@@ -70,8 +71,8 @@ FUNCTION HV_FILENAME_CONVENTION, hvs, create = create, split = split, construct 
         endif else begin
            detector = NotGiven
         endelse
-        if tag_exist(hvs,'measurement') then begin
-           if hvs.measurement eq '' then measurement = NotGiven else measurement = hvs.measurement
+        if tag_exist(hvsi,'measurement') then begin
+           if hvsi.measurement eq '' then measurement = NotGiven else measurement = hvsi.measurement
         endif else begin
            measurement = NotGiven
         endelse
@@ -103,7 +104,7 @@ FUNCTION HV_FILENAME_CONVENTION, hvs, create = create, split = split, construct 
 ; Take a filename and split it into its components
 ;
   if keyword_set(split) then begin
-     z = strsplit(hvs,'_',/extract)
+     z = strsplit(hvsi,'_',/extract)
      answer = {yy:z[0], mm:z[1], dd:z[2], hh:z[3], mmm:z[4], ss:z[5], detector:z[6],$
                observatory:z[7], instrument:z[8], detector:z[9], measurement:z[10]}
   endif

--- a/idl/gen/hv_jp2_transfer.pro
+++ b/idl/gen/hv_jp2_transfer.pro
@@ -48,9 +48,9 @@
 ; those files from the outgoing directory.
 ;
 ;
-PRO HV_JP2_TRANSFER,write_this, ; a permitted project - see HV_WRITTENBY for a LIST of permitted projects
+PRO HV_JP2_TRANSFER,write_this,$ ; a permitted project - see HV_WRITTENBY for a LIST of permitted projects
                     ntransfer = n,$ ; number of files transferred
-                    web = web, $ ; wrote the details of the transfer toa text file that can be picked up by HV_JP2GEN_MONITOR
+                    web = web,$ ; wrote the details of the transfer toa text file that can be picked up by HV_JP2GEN_MONITOR
                     delete_transferred = delete_transferred,$ ; delete the transferred files from the outgoing directory
                     force_delete = force_delete,$ ; force the delete of the JP2 file
                     sdir = sdir ; directory where the JP2 files are stored

--- a/idl/gen/hv_jp2_transfer.pro
+++ b/idl/gen/hv_jp2_transfer.pro
@@ -48,7 +48,8 @@
 ; those files from the outgoing directory.
 ;
 ;
-PRO HV_JP2_TRANSFER,ntransfer = n,$ ; number of files transferred
+PRO HV_JP2_TRANSFER,write_this,
+                    ntransfer = n,$                                             ; number of files transferred
                     web = web, $ ; wrote the details of the transfer toa text file that can be picked up by HV_JP2GEN_MONITOR
                     delete_transferred = delete_transferred,$ ; delete the transferred files from the outgoing directory
                     force_delete = force_delete,$ ; force the delete of the JP2 file
@@ -57,10 +58,10 @@ PRO HV_JP2_TRANSFER,ntransfer = n,$ ; number of files transferred
 ;
 ; Get various details about the setup
 ;
-  wby = HV_WRITTENBY()
+  wby = HV_WRITTENBY(write_this)
   g = HVS_GEN()
   storage = HV_STORAGE()
-  storage2 = HV_STORAGE(nickname = 'HV_TRANSFER_LOGS',/no_db,/no_jp2)
+  storage2 = HV_STORAGE(write_this,nickname = 'HV_TRANSFER_LOGS',/no_db,/no_jp2)
 ;
 ; Transfer start-time
 ;

--- a/idl/gen/hv_jp2_transfer.pro
+++ b/idl/gen/hv_jp2_transfer.pro
@@ -48,8 +48,8 @@
 ; those files from the outgoing directory.
 ;
 ;
-PRO HV_JP2_TRANSFER,write_this,
-                    ntransfer = n,$                                             ; number of files transferred
+PRO HV_JP2_TRANSFER,write_this, ; a permitted project - see HV_WRITTENBY for a LIST of permitted projects
+                    ntransfer = n,$ ; number of files transferred
                     web = web, $ ; wrote the details of the transfer toa text file that can be picked up by HV_JP2GEN_MONITOR
                     delete_transferred = delete_transferred,$ ; delete the transferred files from the outgoing directory
                     force_delete = force_delete,$ ; force the delete of the JP2 file

--- a/idl/gen/hv_jp2_transfer.pro
+++ b/idl/gen/hv_jp2_transfer.pro
@@ -60,8 +60,7 @@ PRO HV_JP2_TRANSFER,write_this,$ ; a permitted project - see HV_WRITTENBY for a 
 ;
   wby = HV_WRITTENBY(write_this)
   g = HVS_GEN()
-  storage = HV_STORAGE()
-  storage2 = HV_STORAGE(write_this,nickname = 'HV_TRANSFER_LOGS',/no_db,/no_jp2)
+  storage = HV_STORAGE(write_this)
 ;
 ; Transfer start-time
 ;
@@ -244,12 +243,12 @@ PRO HV_JP2_TRANSFER,write_this,$ ; a permitted project - see HV_WRITTENBY for a 
 ;
 ; Write a logfile describing what was transferred
 ;
-  HV_LOG_WRITE,'transfer_log',transfer_results,transfer = transfer_start_time + '_'
+  HV_LOG_WRITE,'transfer_log',transfer_results,transfer = transfer_start_time + '_', write_this=write_this
 ;
 ; Write a file for the web, if required
 ;
-  IF keyword_set(web) then begin
-     HV_WEB_TXTNOTE,progname,transfer_results,/details
-  ENDIF
+;  IF keyword_set(web) then begin
+;     HV_WEB_TXTNOTE,progname,transfer_results,/details
+;  ENDIF
   return
 end

--- a/idl/gen/hv_jp2_transfer_schedule.pro
+++ b/idl/gen/hv_jp2_transfer_schedule.pro
@@ -1,12 +1,15 @@
 ;
 ; Transfer JP2 files to remote machine once every "cadence" minutes
 ;
-PRO HV_JP2_TRANSFER_SCHEDULE,cadence,_extra = _extra
+; This program also defines the value of 'write_this', which is used
+; everywhere to define the directories where the files are writte to
+; and read from.
+PRO HV_JP2_TRANSFER_SCHEDULE,cadence,write_this,_extra = _extra
   progname = 'HV_JP2_TRANSFER_SCHEDULE'
   timestart = systime(0)
   n = long(0)
   repeat begin
-     hv_jp2_transfer,ntransfer = ntransfer,/web, _extra = _extra
+     hv_jp2_transfer,write_this,ntransfer = ntransfer,/web, _extra = _extra
      n = n + long(1)
      HV_REPEAT_MESSAGE,progname,n,timestart,/web,more = ['Number of files transferred = ' + trim(ntransfer)]
      HV_WAIT,progname,cadence,/minutes,/web

--- a/idl/gen/hv_log_write.pro
+++ b/idl/gen/hv_log_write.pro
@@ -4,11 +4,11 @@
 ;
 ;-
 PRO HV_LOG_WRITE,hvs, log_comment, log_filename = log_filename,$
-                 transfer = transfer
+                 transfer = transfer, write_this=write_this
   if is_struct(hvs) then begin
-     storage = HV_STORAGE(nickname = hvs.details.nickname)
-     filename = HV_FILENAME_CONVENTION(hvs,/create)
-     log = HV_WRITE_LIST_JP2_MKDIR(hvs,storage.log_location)
+     storage = HV_STORAGE(hvs.hvsi.write_this, nickname=hvs.hvsi.details.nickname)
+     filename = HV_FILENAME_CONVENTION(hvs.hvsi,/create)
+     log = HV_WRITE_LIST_JP2_MKDIR(hvs.hvsi, storage.log_location)
      log_filename = log + filename + '.' + systime(0) + '.log'
      HV_WRT_ASCII,log_comment,log_filename
   endif else begin
@@ -19,7 +19,7 @@ PRO HV_LOG_WRITE,hvs, log_comment, log_filename = log_filename,$
 ;
 ; Get the storage
 ;
-        storage = HV_STORAGE(nickname = 'HV_TRANSFER_LOGS',/no_db,/no_jp2)
+        storage = HV_STORAGE(write_this, nickname = 'HV_TRANSFER_LOGS',/no_db,/no_jp2)
 ;
 ; Get today's date
 ;

--- a/idl/gen/hv_log_write.pro
+++ b/idl/gen/hv_log_write.pro
@@ -2,13 +2,15 @@
 ;+
 ; Do the log file
 ;
+; The input to this function is an hvsi structure ONLY.
+;
 ;-
-PRO HV_LOG_WRITE,hvs, log_comment, log_filename = log_filename,$
+PRO HV_LOG_WRITE,hvsi, log_comment, log_filename = log_filename,$
                  transfer = transfer, write_this=write_this
-  if is_struct(hvs) then begin
-     storage = HV_STORAGE(hvs.hvsi.write_this, nickname=hvs.hvsi.details.nickname)
-     filename = HV_FILENAME_CONVENTION(hvs.hvsi,/create)
-     log = HV_WRITE_LIST_JP2_MKDIR(hvs.hvsi, storage.log_location)
+  if is_struct(hvsi) then begin
+     storage = HV_STORAGE(hvsi.write_this, nickname=hvsi.details.nickname)
+     filename = HV_FILENAME_CONVENTION(hvsi,/create)
+     log = HV_WRITE_LIST_JP2_MKDIR(hvsi, storage.log_location)
      log_filename = log + filename + '.' + systime(0) + '.log'
      HV_WRT_ASCII,log_comment,log_filename
   endif else begin

--- a/idl/gen/hv_repeat_message.pro
+++ b/idl/gen/hv_repeat_message.pro
@@ -31,17 +31,17 @@ PRO HV_REPEAT_MESSAGE, progname,n,t, more = more, web = web
 ; picked up by another script to create a web page showing the latest
 ; creation details
 ;
-  if keyword_set(web) then begin
-     storage = HV_STORAGE()
-     filename = 'latest.' + progname + '.txt'
-     dir = storage.web
-     nb = n_elements(a) + 2
-     b = strarr(nb)
-     b[0] = '<P>'
-     b[1:n_elements(a)] = a[*] + '<BR>'
-     b[nb-1] = '</P>'
-     HV_WRT_ASCII,b,dir + filename
-  endif
+;  if keyword_set(web) then begin
+;     storage = HV_STORAGE()
+;     filename = 'latest.' + progname + '.txt'
+;     dir = storage.web
+;     nb = n_elements(a) + 2
+;     b = strarr(nb)
+;     b[0] = '<P>'
+;     b[1:n_elements(a)] = a[*] + '<BR>'
+;     b[nb-1] = '</P>'
+;     HV_WRT_ASCII,b,dir + filename
+;  endif
   return
 end
 

--- a/idl/gen/hv_storage.pro
+++ b/idl/gen/hv_storage.pro
@@ -13,9 +13,9 @@
 ; 
 ; for more information on setting up JPGen
 ;
-FUNCTION HV_STORAGE,nickname = nickname, no_db = no_db, no_log = no_log, no_jp2 = no_jp2
+FUNCTION HV_STORAGE,write_this,nickname = nickname, no_db = no_db, no_log = no_log, no_jp2 = no_jp2
 ;
-  wby = HV_WRITTENBY()
+  wby = HV_WRITTENBY(write_this)
 ;
 ; Where the HV programs are kept
 ;

--- a/idl/gen/hv_wait.pro
+++ b/idl/gen/hv_wait.pro
@@ -38,17 +38,17 @@ PRO HV_WAIT, progname,t,seconds = seconds, minutes = minutes, hours = hours, day
 ;
 ;
   print,wait_message
-  if keyword_Set(web) then begin
-     filename = 'latest.' + progname + '.txt'
-     storage = HV_STORAGE()
-     dir = storage.web
-     nb = 3
-     b = strarr(nb)
-     b[0] = '<P>'
-     b[1] = wait_message + '<BR>'
-     b[nb-1] = '</P>'
-     HV_WRT_ASCII,b,dir + filename,/append
-  endif
+;  if keyword_Set(web) then begin
+;     filename = 'latest.' + progname + '.txt'
+;     storage = HV_STORAGE()
+;     dir = storage.web
+;     nb = 3
+;     b = strarr(nb)
+;     b[0] = '<P>'
+;     b[1] = wait_message + '<BR>'
+;     b[nb-1] = '</P>'
+;     HV_WRT_ASCII,b,dir + filename,/append
+;  endif
 
   wait,t*f
   return

--- a/idl/gen/hv_write_jp2_lwg.pro
+++ b/idl/gen/hv_write_jp2_lwg.pro
@@ -82,7 +82,7 @@
 ;
 ;-
 
-PRO HV_WRITE_JP2_LWG,file,image,bit_rate=bit_rate,n_layers=n_layers,n_levels=n_levels,fitsheader=fitsheader,quiet=quiet,kdu_lib_location=kdu_lib_location,details = details,measurement = measurement,reversible = reversible,_extra = _extra
+PRO HV_WRITE_JP2_LWG,file,image,write_this,bit_rate=bit_rate,n_layers=n_layers,n_levels=n_levels,fitsheader=fitsheader,quiet=quiet,kdu_lib_location=kdu_lib_location,details = details,measurement = measurement,reversible = reversible,_extra = _extra
 ;
   progname = 'HV_WRITE_JP2_LWG'
 ;
@@ -156,7 +156,7 @@ PRO HV_WRITE_JP2_LWG,file,image,bit_rate=bit_rate,n_layers=n_layers,n_levels=n_l
 ;
 ; Get contact details
 ;
-        wby = HV_WRITTENBY()
+        wby = HV_WRITTENBY(write_this)
 ;
 ; Set the JP2 compression details, override defaults if set from
 ; function call

--- a/idl/gen/hv_write_list_jp2.pro
+++ b/idl/gen/hv_write_list_jp2.pro
@@ -29,7 +29,7 @@ PRO HV_WRITE_LIST_JP2,hvs,jp2_filename = jp2_filename,already_written = already_
      loc = HV_WRITE_LIST_JP2_MKDIR(hvs.hvsi,storage.jp2_location)
      filename = HV_FILENAME_CONVENTION(hvs.hvsi,/create)
      jp2_filename = loc + filename
-     HV_WRITE_JP2_LWG,jp2_filename,hvs.img,fitsheader = hvs.hvsi.header,details = details,measurement = hvs.hvsi.measurement
+     HV_WRITE_JP2_LWG,jp2_filename,hvs.img,hvs.hvsi.write_this,fitsheader = hvs.hvsi.header,details = details,measurement = hvs.hvsi.measurement
      jp2_filename = loc + filename + '.jp2'
      HV_DB,hvs.hvsi,/update
   endif else begin

--- a/idl/gen/hv_write_list_jp2.pro
+++ b/idl/gen/hv_write_list_jp2.pro
@@ -25,7 +25,7 @@ PRO HV_WRITE_LIST_JP2,hvs,jp2_filename = jp2_filename,already_written = already_
 ;
   if (NOT(already_written) or overwrite) then begin
      details = hvs.hvsi.details
-     storage = HV_STORAGE(nickname = details.nickname)
+     storage = HV_STORAGE(hvs.hvsi.write_this, nickname = details.nickname)
      loc = HV_WRITE_LIST_JP2_MKDIR(hvs.hvsi,storage.jp2_location)
      filename = HV_FILENAME_CONVENTION(hvs.hvsi,/create)
      jp2_filename = loc + filename

--- a/idl/gen/hv_write_list_jp2_mkdir.pro
+++ b/idl/gen/hv_write_list_jp2_mkdir.pro
@@ -2,9 +2,9 @@
 ; Create the subdirectory structure as required
 ;
 ;
-FUNCTION HV_WRITE_LIST_JP2_MKDIR,hvs,dir,return_path_only = return_path_only
+FUNCTION HV_WRITE_LIST_JP2_MKDIR,hvsi, dir, return_path_only=return_path_only
 
-  dirCon = HV_DIRECTORY_CONVENTION(hvs.yy,hvs.mm,hvs.dd,hvs.measurement)
+  dirCon = HV_DIRECTORY_CONVENTION(hvsi.yy, hvsi.mm, hvsi.dd, hvsi.measurement)
   n = n_elements(dirCon)
 
   for i = 0,n-1 do begin

--- a/idl/gen/hvs_gen.pro
+++ b/idl/gen/hvs_gen.pro
@@ -33,15 +33,12 @@ FUNCTION HVS_GEN
 ;
 ; Get the source details
 ;
-  wby = HV_WRITTENBY()
-  loc = wby.local.jp2gen
-  bzr_revno = HV_BZR_REVNO_HANDLER(loc)
   source = {institute:'NASA-GSFC',$
             contact:'ESA/NASA Helioviewer Project [contact the Helioviewer Project at webmaster@helioviewer.org]',$
             all_code:'https://launchpad.net/helioviewer',$
             jp2gen_code:'https://launchpad.net/jp2gen',$
             jp2gen_version:'0.8',$
-            jp2gen_branch_revision:bzr_revno}
+            jp2gen_branch_revision:0}
 ;
 ; Set up default values for JP2 compression
 ;

--- a/idl/gen/hvs_gen.pro
+++ b/idl/gen/hvs_gen.pro
@@ -38,7 +38,7 @@ FUNCTION HVS_GEN
             all_code:'https://launchpad.net/helioviewer',$
             jp2gen_code:'https://launchpad.net/jp2gen',$
             jp2gen_version:'0.8',$
-            jp2gen_branch_revision:0}
+            jp2gen_branch_revision:'See github.com/Helioviewer-Project/jp2gen'}
 ;
 ; Set up default values for JP2 compression
 ;

--- a/idl/local/EXAMPLE_hv_writtenby.pro
+++ b/idl/local/EXAMPLE_hv_writtenby.pro
@@ -22,48 +22,40 @@
 ; webpage: the location of the JP2Gen monitoring webpage.  
 ;          This webpage will allow you to monitor file creation and transfer services of your JP2 installtion
 ;
-FUNCTION HV_WRITTENBY;,name = name
+FUNCTION HV_WRITTENBY,write_this
 
-  answer = {local:{institute:'NASA-GSFC',$
-                    contact:'Helioviewer Project (webmaster@helioviewer.org)',$
-                    kdu_lib_location:'~/KDU/Kakadu/v6_1_1-00781N/bin/Mac-x86-64-gcc/',$
-                    jp2gen_write:'/home/ireland/hv_latest/',$
-                    jp2gen:'/home/ireland/hv/jp2gen-jack/'},$
-             transfer:{local:{group:'ireland',$
-                              tcmd_linux:'rsync',$
-                              tcmd_osx:'/usr/local/bin/rsync'},$
-                       remote:{user:'ireland',$
-                               machine:'helioviewer.nascom.nasa.gov',$
-                               incoming:'/home/ireland/incoming/',$
-                               group:'helioviewer'}},$
-             webpage:'/service/www/',$
-             manual_revision_number:'97 [2011/03/25, https://launchpad.net/jp2gen]'}
+  ;
+  supported = LIST('soho', 'stereo')
+  if supported.Where(write_this) eq !NULL then begin
+     print,'Instrument ' + write_this + ' is not supported.'
+     answer = 0
+     stop
+  endif else begin
+   ; Remote machine
+    remote_machine = 'the_remote_machine
 
-;;   if name eq 'default' then begin
-;;      answer = default
-;;   endif
-;; ;
-;; ; Add in other choices as approprate
-;; ;
-;;   if name eq 'helioviewer-production' then begin
-;;      answer = default
-;;      answer.local.jp2gen_write = '/home/ireland/JP2Gen_helioviewer/'
-;;      answer.transfer.remote.incoming = '/home/ireland/incoming/'
-;;   endif
-;;   if name eq 'helioviewer-test' then begin
-;;      answer = default
-;;      answer.local.jp2gen_write = '/home/ireland/JP2Gen_helioviewer/'
-;;      answer.transfer.remote.incoming = '/home/ireland/test/'
-;;   endif
+  ; Local root
+    local_root = '/my/local/machine/'
+    
+  ; Remote root where all the 
+    remote_root = '/where/the/data/goes/to/'
 
-;;   if name eq 'delphi-test' then begin
-;;      answer = default
-;;      answer.local.jp2gen_write = '/home/ireland/JP2Gen_delphi_test/'
-;;      answer.transfer.remote.machine = 'delphi.nascom.nasa.gov'
-;;      answer.transfer.remote.incoming = '/home/ireland/test/'
-;;   endif
-
-
+  ; Locations required
+    answer = {local:{institute:'NASA-GSFC',$
+                     contact:'Helioviewer Project (webmaster@helioviewer.org)',$
+                     kdu_lib_location:'~/KDU/Kakadu/v6_1_1-00781N/bin/Mac-x86-64-gcc/',$
+                     jp2gen_write: local_root + write_this + '/', $
+                     jp2gen:'/home/ireland/hvp/jp2gen/jp2gen/'},$
+              transfer:{local:{group:'ireland',$
+                               tcmd_linux:'rsync',$
+                               tcmd_osx:'/usr/local/bin/rsync'},$
+                        remote:{user:'jireland',$
+                                machine: remote_machine,$
+                                incoming: remote_root + write_this + '_incoming/',$
+                                group:'helioviewer'}},$
+              webpage:'/service/www/',$
+              manual_revision_number:'see github.com/Helioviewer-Project/jp2gen'}
+  endelse
   return,answer
 END
 

--- a/idl/rhessi/quicklook/hv_rhessi_quicklook_get_images.pro
+++ b/idl/rhessi/quicklook/hv_rhessi_quicklook_get_images.pro
@@ -63,6 +63,9 @@ pro hv_rhessi_quicklook_get_images, timerange, jp2_filename=jp2_filename, alread
      return
   endif
 
+; Count of filenames
+all_jp2_filenames = ['aa']
+
 ; At least one flare in the timerange
   for i = 0, count-1 do begin
 
@@ -92,6 +95,9 @@ pro hv_rhessi_quicklook_get_images, timerange, jp2_filename=jp2_filename, alread
 
 ; Convert to a structure
            header = fitshead2struct(fits_header)
+           ;print, eband[*, j]
+           ;print, fits_header
+           ;stop
 
 ; Observation date
            date_obs = header.date_obs
@@ -154,6 +160,11 @@ pro hv_rhessi_quicklook_get_images, timerange, jp2_filename=jp2_filename, alread
                         already_written=already_written, $
                         overwrite=overwrite
 ;
+; Keep a running list of the filenames returned
+;
+           all_jp2_filenames = [all_jp2_filenames, jp2_filename]
+
+;
 ; Create contour information
 ;
            if write_contour eq 1 then begin
@@ -167,7 +178,15 @@ pro hv_rhessi_quicklook_get_images, timerange, jp2_filename=jp2_filename, alread
         endfor
      endelse
   endfor
-
+;
+; Create the filename return variable
+;
+  n_jp2_filenames = n_elements(all_jp2_filenames) - 1
+  if n_jp2_filenames eq 0 then begin
+     jp2_filename = 0
+  endif else begin
+     jp2_filename = all_jp2_filenames[1:n_jp2_filenames]
+  endelse
   return
 end
 

--- a/idl/rhessi/quicklook/hv_rhessi_quicklook_write_images.pro
+++ b/idl/rhessi/quicklook/hv_rhessi_quicklook_write_images.pro
@@ -1,0 +1,81 @@
+;
+; 23 January 1018
+;
+; HV_RHESSI_QUICKLOOK_WRITE_IMAGES
+;
+; Convert RHESSI Quiicklook FITS files to JP2
+; 
+; Pass a start date and an end date in the form
+;
+; 2009/11/18
+;
+; 
+;
+
+PRO HV_RHESSI_QUICKLOOK_WRITE_IMAGES,date_start = ds, $ ; date the automated processing starts
+                         date_end = de, $   ; date to end automated processing starts
+                         details_file = details_file,$                     ; call to an explicit details file
+                         copy2outgoing = copy2outgoing,$                   ; copy to the outgoing directory
+                         once_only = once_only,$                           ;  if set, the time range is passed through once only
+                         overwrite = overwrite,$
+                         writtenby = writtenby
+;
+  progname = 'HV_RHESSI_QUICKLOOK_WRITE_IMAGES'
+;
+; use the default RHESSI file is no other one is specified
+;
+  if not(KEYWORD_SET(details_file)) then begin
+     details_file = 'hvs_rhessi_quicklook'
+  endif
+
+;
+; Assign the default writtenby choice if no other present
+;
+  if not(KEYWORD_SET(writtenby)) then begin
+     writtenby = 'default'
+  endif
+;
+  info = CALL_FUNCTION(details_file)
+  nickname = info.nickname
+;
+  timestart = systime(0)
+  count = long(0)
+;
+  repeat begin
+;
+; Get today's date in UT
+;
+     ndays = 7
+     get_utc,utc,/ecs,/date_only
+     utc2date = anytim2cal( anytim2tai(utc)-ndays*24*60*60.0,form=11,/date )
+     if (count eq 0) then begin
+        if not(keyword_set(ds)) then ds = utc2date
+        if not(keyword_set(de)) then de = utc
+     endif else begin
+        ds = utc2date
+        de = utc
+     endelse
+;
+; Get the images
+;
+     print,' '
+     print,progname + ': Processing... ' + ds + ' to ' + de
+     hv_rhessi_quicklook_get_images, [ds, de], jp2_filename=jp2_filename, already_written=already_written, $
+                  overwrite=overwrite
+;
+; Copy them to the outgoing directory.
+;
+     if keyword_set(copy2outgoing) then begin
+        HV_COPY2OUTGOING,jp2_filename, delete_original=delete_original
+     endif
+;
+; Wait 15 minutes before looking for more data
+;
+     count = count + 1
+     HV_REPEAT_MESSAGE,progname,count,timestart, more = ['examined ' + ds + ' to ' + de],/web
+     HV_WAIT,progname,15,/minutes,/web
+
+  endrep until 1 eq keyword_set(once_only)
+
+  return
+end

--- a/idl/rhessi/quicklook/hv_rhessi_quicklook_write_images.pro
+++ b/idl/rhessi/quicklook/hv_rhessi_quicklook_write_images.pro
@@ -45,6 +45,13 @@ PRO HV_RHESSI_QUICKLOOK_WRITE_IMAGES,date_start = ds, $ ; date the automated pro
 ;
 ; Get today's date in UT
 ;
+; Number of days back to search.  This should be enough in most
+; circumstances.  According to the RHESSI team, the lag for some
+; flares can be on the order of weeks.  In addition, the entire
+; quicklook archive can, and has been reprocessed.  This means that
+; the images available on helioviewer at any given time may not be an
+; accurate representation of the current state of the quicklook
+; archive.
      ndays = 7
      get_utc,utc,/ecs,/date_only
      utc2date = anytim2cal( anytim2tai(utc)-ndays*24*60*60.0,form=11,/date )

--- a/idl/soho/lasco/hv_las_c2_write_hvs2.pro
+++ b/idl/soho/lasco/hv_las_c2_write_hvs2.pro
@@ -207,7 +207,8 @@ FUNCTION HV_LAS_C2_WRITE_HVS2,dir,ld,details = details
              hh:hh,$
              mmm:mmm,$
              ss:ss,$
-             milli:milli}
+             milli:milli,$
+             write_this:'soho'}
      hvs = {img:image_new,hvsi:hvsi}
 
      HV_MAKE_JP2,hvs,jp2_filename = jp2_filename,already_written = already_written

--- a/idl/soho/lasco/hv_las_c3_write_hvs2.pro
+++ b/idl/soho/lasco/hv_las_c3_write_hvs2.pro
@@ -245,7 +245,8 @@ FUNCTION HV_LAS_C3_WRITE_HVS2,dir,ld,details = details
              hh:hh,$
              mmm:mmm,$
              ss:ss,$
-             milli:milli}
+             milli:milli,$
+             write_this:'soho'}
      hvs = {img:image_new,hvsi:hvsi}
 
      HV_MAKE_JP2,hvs,jp2_filename = jp2_filename,already_written = already_written

--- a/idl/soho/lasco/hv_lasco_c2_prep2jp2.pro
+++ b/idl/soho/lasco/hv_lasco_c2_prep2jp2.pro
@@ -68,7 +68,7 @@ PRO HV_LASCO_C2_PREP2JP2,ds,de,details_file = details_file,called_by = called_by
 ;
 ; Call details of storage locations
 ;
-     storage = HV_STORAGE(nickname = nickname)
+     storage = HV_STORAGE('soho', nickname = nickname)
 ;
 ; Write direct to JP2 from FITS
 ;
@@ -86,7 +86,7 @@ PRO HV_LASCO_C2_PREP2JP2,ds,de,details_file = details_file,called_by = called_by
 ; Copy2outgoing
 ;
      if keyword_set(copy2outgoing) then begin
-        HV_COPY2OUTGOING,prepped
+        HV_COPY2OUTGOING,prepped, 'soho'
      endif
   endelse
 

--- a/idl/soho/lasco/hv_lasco_c3_prep2jp2.pro
+++ b/idl/soho/lasco/hv_lasco_c3_prep2jp2.pro
@@ -73,7 +73,7 @@ PRO HV_LASCO_C3_PREP2JP2,ds,de,details_file = details_file,called_by = called_by
 ;
 ; Call details of storage locations
 ;
-     storage = HV_STORAGE(nickname = nickname)
+     storage = HV_STORAGE('soho',nickname = nickname)
 ;
 ; Write direct to JP2 from FITS
 ;
@@ -90,7 +90,7 @@ PRO HV_LASCO_C3_PREP2JP2,ds,de,details_file = details_file,called_by = called_by
 ; Copy2outgoing
 ;
      if keyword_set(copy2outgoing) then begin
-        HV_COPY2OUTGOING,prepped
+        HV_COPY2OUTGOING,prepped,'soho'
      endif
   endelse
 

--- a/idl/soho/lasco/hv_lasco_get_filenames.pro
+++ b/idl/soho/lasco/hv_lasco_get_filenames.pro
@@ -75,10 +75,14 @@ FUNCTION HV_LASCO_GET_FILENAMES, t1,t2, nickname,info
      sourcefile    = sdir +'img_hdr.txt'
      print, 'Looking for files in ', sdir
      print, 'Looking for sourcefile ', sourcefile
-     hvs = {img:-1,header:-1,measurement: info.details[0].measurement,$
+                                ; Define a hvsi structure here to
+                                ; carry the write_this variable in the
+                                ; expected place
+     hvsi = {header:-1,measurement: info.details[0].measurement,$
             yy:STRMID(nds,0,4),mm:STRMID(nds,5,2),dd:STRMID(nds,8,2),$
             hh:'log', mmm:'log', ss:'log', milli:'log',$
-            details:info}
+            details:info, write_this:'soho'}
+     hvs = {img:-1, hvsi:hvsi}
 
      IF file_test(sourcefile) THEN BEGIN
                                 ; read img_hdr.txt

--- a/idl/soho/lasco/hv_lasco_get_filenames.pro
+++ b/idl/soho/lasco/hv_lasco_get_filenames.pro
@@ -103,7 +103,7 @@ FUNCTION HV_LASCO_GET_FILENAMES, t1,t2, nickname,info
            if (n_elements(words) lt 12) then begin
               log_comment = progname + ': img_hdr.txt malformed for this file: '+sourcefile
               print, log_comment
-              HV_LOG_WRITE,hvs,log_comment
+              HV_LOG_WRITE,hvs.hvsi,log_comment
            endif else begin
               file=strsplit(words[0],'.',/extract)
               newfile = sdir + words[0]
@@ -135,7 +135,7 @@ FUNCTION HV_LASCO_GET_FILENAMES, t1,t2, nickname,info
            endelse
         endfor
      ENDIF ELSE BEGIN 
-        HV_LOG_WRITE,hvs,progname + ': Could not open '+sourcefile
+        HV_LOG_WRITE,hvs.hvsi,progname + ': Could not open '+sourcefile
      ENDELSE
   ENDFOR                        ; juldays
 
@@ -143,7 +143,7 @@ FUNCTION HV_LASCO_GET_FILENAMES, t1,t2, nickname,info
      print,' NO IMAGES ARE FOUND: CHECK YOUR INPUT DATES'
   endif else begin
      image_list=image_list[1:*]
-     HV_LOG_WRITE,hvs,image_list
+     HV_LOG_WRITE,hvs.hvsi,image_list
 
 ;     printf, log, ' Number of images that will be downloaded: ',n_elements(image_list) 
 ;     save, filename=dir.work+detector+'_image_list.sav', image_list

--- a/idl/soho/lasco/hv_lasco_get_filenames.pro
+++ b/idl/soho/lasco/hv_lasco_get_filenames.pro
@@ -41,7 +41,7 @@ FUNCTION HV_LASCO_GET_FILENAMES, t1,t2, nickname,info
 ;
   g = HVS_GEN()
 ;
-  ldr = getenv('LZ_IMG') + '/' + 'level_05/' ; where the LASCO data is
+  ldr = getenv('LZ_IMG') ; + '/' + 'level_05/' ; where the LASCO data is
 ;
 ; If we are calling this program to get the quicklooks, change ldr
 ;
@@ -64,6 +64,7 @@ FUNCTION HV_LASCO_GET_FILENAMES, t1,t2, nickname,info
   date2 = anytim2utc(t2)
   image_list = [g.MinusOneString]
 
+  print, 'Looking for files in ', ldr
   FOR mjd=date1.mjd,date2.mjd DO BEGIN
      newday = {mjd:mjd,time:0.0}
      nds = utc2str(newday,/date_only)
@@ -72,7 +73,8 @@ FUNCTION HV_LASCO_GET_FILENAMES, t1,t2, nickname,info
 ;         sourcefile    = dir.data+day+'/'+detector+'/'+'img_hdr.txt'
      sdir = ldr + day + path_sep() + detector + path_sep()
      sourcefile    = sdir +'img_hdr.txt'
-
+     print, 'Looking for files in ', sdir
+     print, 'Looking for sourcefile ', sourcefile
      hvs = {img:-1,header:-1,measurement: info.details[0].measurement,$
             yy:STRMID(nds,0,4),mm:STRMID(nds,5,2),dd:STRMID(nds,8,2),$
             hh:'log', mmm:'log', ss:'log', milli:'log',$

--- a/idl/soho/lasco/hv_lasco_prep2jp2_ql.pro
+++ b/idl/soho/lasco/hv_lasco_prep2jp2_ql.pro
@@ -24,6 +24,10 @@ PRO HV_LASCO_PREP2JP2_QL,date_start = ds, $ ; date the automated processing star
 ;
   progname = 'HV_LASCO_PREP2JP2_QL'
 ;
+;
+;
+ 
+;
 ; Make sure at least one of C2 or C3 is called
 ;
   if not(keyword_set(c2)) and not(keyword_set(c3)) then begin

--- a/idl/stereo/cor1/hv_cor1_by_date.pro
+++ b/idl/stereo/cor1/hv_cor1_by_date.pro
@@ -139,7 +139,7 @@ pro hv_cor1_by_date, date, only_synoptic=only_synoptic, overwrite=overwrite,copy
           if not(already_written) and cor1FilesExist then begin
              hv_cor1_prep2jp2, cor1Files, overwrite=overwrite, jp2_filename = jp2_filename,recalculate_crpix = recalculate_crpix
              if keyword_set(copy2outgoing) then begin
-                HV_COPY2OUTGOING,[jp2_filename], delete_original=delete_original
+                HV_COPY2OUTGOING,[jp2_filename], 'stereo', delete_original=delete_original
              endif
           endif
           if already_written then begin

--- a/idl/stereo/cor1/hv_cor1_prep2jp2.pro
+++ b/idl/stereo/cor1/hv_cor1_prep2jp2.pro
@@ -125,7 +125,8 @@ pro hv_cor1_prep2jp2, filename, jp2_filename=jp2_filename, $
           mmm: string(ext.minute, format='(I2.2)'), $
           ss: string(ext.second, format='(I2.2)'), $
           milli: string(ext.millisecond, format='(I3.3)'), $
-          details: details}
+          details: details,$
+          write_this: 'stereo'}
   hvs = {img: image, hvsi: hvsi}
 ;
 ;  Create the JPEG2000 file.

--- a/idl/stereo/cor2/hv_cor2_auto.pro
+++ b/idl/stereo/cor2/hv_cor2_auto.pro
@@ -1,7 +1,7 @@
 ;
+; unfinished and a basic copy of hv_cor1_auto.pro
 ;
-;
-PRO HV_COR2_AUTO,date_start = ds, $ ; date the automated processing starts
+PRO HV_COR1_AUTO,date_start = ds, $ ; date the automated processing starts
                  ndaysBack = ndaysBack, $   ; date to end automated processing starts
                  details_file = details_file,$                           ; call to an explicit details file
                  alternate_backgrounds = alternate_backgrounds,$         ; location of the alternate backgrounds
@@ -9,7 +9,7 @@ PRO HV_COR2_AUTO,date_start = ds, $ ; date the automated processing starts
                  once_only = once_only,$                                 ;  if set, the time range is passed through once only
                  writtenby = writtenby
 ;
-  progname = 'hv_cor2_auto'
+  progname = 'hv_cor1_auto'
   count = 0
 ;
   repeat begin
@@ -29,7 +29,7 @@ PRO HV_COR2_AUTO,date_start = ds, $ ; date the automated processing starts
         print,' '
         print,progname + ': Processing all files on ' + date
 
-        HV_COR2_BY_DATE,date, copy2outgoing = copy2outgoing
+        HV_COR1_BY_DATE,date, copy2outgoing = copy2outgoing
 
      endfor
 ;

--- a/idl/stereo/cor2/hv_cor2_auto.pro
+++ b/idl/stereo/cor2/hv_cor2_auto.pro
@@ -1,0 +1,46 @@
+;
+;
+;
+PRO HV_COR2_AUTO,date_start = ds, $ ; date the automated processing starts
+                 ndaysBack = ndaysBack, $   ; date to end automated processing starts
+                 details_file = details_file,$                           ; call to an explicit details file
+                 alternate_backgrounds = alternate_backgrounds,$         ; location of the alternate backgrounds
+                 copy2outgoing = copy2outgoing,$                         ; copy to the outgoing directory
+                 once_only = once_only,$                                 ;  if set, the time range is passed through once only
+                 writtenby = writtenby
+;
+  progname = 'hv_cor2_auto'
+  count = 0
+;
+  repeat begin
+;
+; Get today's date in UT
+;
+     if not(keyword_set(ds)) then begin
+        get_utc,date_start
+     endif
+;
+     for i = 0,ndaysback do begin
+
+        this_date = date_start
+        this_date.mjd = this_date.mjd - i
+        date = utc2str(this_date,/date_only,/ecs)
+
+        print,' '
+        print,progname + ': Processing all files on ' + date
+
+        HV_COR2_BY_DATE,date, copy2outgoing = copy2outgoing
+
+     endfor
+;
+; Wait 15 minutes before looking for more data
+;
+     count = count + 1
+     HV_REPEAT_MESSAGE,progname,count,timestart, more = ['examined ' + ds + '.',report],/web
+     HV_WAIT,progname,15,/minutes,/web
+
+
+  endrep until  1 eq keyword_set(once_only)
+
+     return
+end

--- a/idl/stereo/cor2/hv_cor2_by_date.pro
+++ b/idl/stereo/cor2/hv_cor2_by_date.pro
@@ -249,7 +249,7 @@ pro hv_cor2_by_date, date, only_synoptic=only_synoptic, overwrite=overwrite,$
                     print,systime() + ': '+ progname + ': Double exposure image being written.'
                     hv_cor2_prep2jp2, filename, overwrite=overwrite, jp2_filename = jp2_filename,recalculate_crpix = recalculate_crpix
                     if keyword_set(copy2outgoing) then begin
-                       HV_COPY2OUTGOING, [jp2_filename], delete_original=delete_original
+                       HV_COPY2OUTGOING, [jp2_filename], 'stereo', delete_original=delete_original
                     endif
                  endif
                  if already_written then begin

--- a/idl/stereo/cor2/hv_cor2_prep2jp2.pro
+++ b/idl/stereo/cor2/hv_cor2_prep2jp2.pro
@@ -174,7 +174,8 @@ pro hv_cor2_prep2jp2, filename, jp2_filename=jp2_filename, $
              mmm: string(ext.minute, format='(I2.2)'), $
              ss: string(ext.second, format='(I2.2)'), $
              milli: string(ext.millisecond, format='(I3.3)'), $
-             details: details}
+             details: details, $
+             write_this: 'stereo'}
      hvs = {img: image, hvsi: hvsi}
 ;
 ;  Create the JPEG2000 file.

--- a/idl/stereo/euvi/hv_euvi_by_date.pro
+++ b/idl/stereo/euvi/hv_euvi_by_date.pro
@@ -158,7 +158,7 @@ pro hv_euvi_by_date, date, only_synoptic=only_synoptic, overwrite=overwrite,$
                  if not(already_written) and file_exist(filename) then begin
                     hv_euvi_prep2jp2, filename, overwrite=overwrite, jp2_filename = jp2_filename,recalculate_crpix = recalculate_crpix
                     if keyword_set(copy2outgoing) then begin
-                       HV_COPY2OUTGOING,[jp2_filename], delete_original=delete_original
+                       HV_COPY2OUTGOING,[jp2_filename], 'stereo', delete_original=delete_original
                     endif
                  endif else begin
                     print,systime() + ': '+ progname + ': file already written. Skipping processing of '+filename+'.'

--- a/idl/stereo/euvi/hv_euvi_prep2jp2.pro
+++ b/idl/stereo/euvi/hv_euvi_prep2jp2.pro
@@ -113,7 +113,8 @@ hvsi = {dir: dir, $
         mmm: string(ext.minute, format='(I2.2)'), $
         ss: string(ext.second, format='(I2.2)'), $
         milli: string(ext.millisecond, format='(I3.3)'), $
-        details: details}
+        details: details, $
+        write_this: 'stereo'}
 hvs = {img: image, hvsi: hvsi}
 ;
 ;  Create the JPEG2000 file.

--- a/idl/stereo/hv_parse_secchi_name_test_in_db.pro
+++ b/idl/stereo/hv_parse_secchi_name_test_in_db.pro
@@ -51,14 +51,15 @@ FUNCTION HV_PARSE_SECCHI_NAME_TEST_IN_DB,filename
      endif
   endif
 
-  hvsi = {yy:yy,$
-          mm:mm,$
-          dd:dd,$
-          dir:dir,$
-          fitsname:name+ext,$
-          measurement:measurement,$
-          details:details,$
-          header:header}
+  hvsi = {yy: yy,$
+          mm: mm,$
+          dd: dd,$
+          dir: dir,$
+          fitsname: name+ext,$
+          measurement: measurement,$
+          details: details,$
+          header: header,$
+          write_this: 'stereo'}
 
   HV_DB,hvsi,already_written = already_written
   return,already_written

--- a/idl/stereo/hv_secchi_cantfindcatalog.pro
+++ b/idl/stereo/hv_secchi_cantfindcatalog.pro
@@ -10,7 +10,7 @@ FUNCTION HV_SECCHI_CANTFINDCATALOG
 ;
 ;
 ;
-  wby = HV_WRITTENBY()
+  wby = HV_WRITTENBY('stereo')
   cantFindCatalogDir = wby.local.jp2gen_write + 'write/v0.8/log/cantfindcatalog/'
   spawn,'mkdir '+ cantFindCatalogDir
   return,cantFindCatalogDir

--- a/py/create_histograms.py
+++ b/py/create_histograms.py
@@ -11,7 +11,7 @@ import matplotlib.dates as mdates
 measurements = ['304'] #, '131', '171', '193', '211', '304', '335', '1600', '1700', '4500']
 storage = os.path.expanduser('~/Data/hvp/aia_color_correction')
 
-
+plt.ion()
 for measurement in measurements:
     print('Measurement = ' + measurement)
     # Define the storage directory
@@ -23,28 +23,75 @@ for measurement in measurements:
     # Number of files
     n = len(filelist)
 
+    # What is considered low level intensities?
+    low_level = 5
+
+    # Number of values
+    n_values = 256
+
     # Storage
-    time_histogram = np.zeros((256, n))
+    values = np.arange(0, n_values)
+    av = np.zeros((n,))
+    av_above_lower_limit = np.zeros_like(av)
+    time_histogram = np.zeros((n_values, n))
     x_lims = []
+
     # Create a histogram
+    bins = -0.5 + np.arange(0, n_values+1)
     for i, f in enumerate(filelist):
         print(f, i, len(filelist))
         m = sunpy.map.Map(f)
         x_lims.append(m.date)
-        for p in range(0, 256):
-            time_histogram[p, i] = np.log10(np.sum(m.data[:, :] == p))
+        time_histogram[:, i] = np.log10(np.histogram(m.data, bins)[0]/m.data.size)
+
+        # Full average
+        this_th = 10.0**time_histogram[:, i]
+        av[i] = np.sum(values*this_th/np.sum(this_th))
+
+        # Average above low level
+        av_above_lower_limit[i] = np.nanmean(m.data[m.data >= low_level])
 
     xlims = mdates.date2num(x_lims)
-    cmap = plt.get_cmap('bwr')
+    cmap = plt.get_cmap('viridis')
     cmap.set_bad(color='k', alpha=1.)
     fig, ax = plt.subplots()
-    ax.imshow(time_histogram, origin='lower', aspect='auto', cmap=cmap,
-              extent=[xlims[0], xlims[1], 0, 255])
+    cax = ax.imshow(time_histogram, origin='lower', aspect='auto', cmap=cmap,
+                    extent=[xlims[0], xlims[-1], 0, n_values-1])
+    ax.plot(xlims, av, label='average', color='k')
+    ax.plot(xlims, av_above_lower_limit, label='average for intensities $\geq${:s}'.format(str(low_level)), color='r')
+    ax.axhline(low_level, label='lower limit={:s}'.format(str(low_level)), linestyle=':', color='k')
+
+    # Set the x-axis to be a date
     ax.xaxis_date()
     date_format = mdates.DateFormatter('%Y-%m-%d')
     ax.xaxis.set_major_formatter(date_format)
     # This simply sets the x-axis data to diagonal so it fits better.
     fig.autofmt_xdate()
 
-    plt.colorbar()
+    # Set the image titles and labels
+    ax.set_title('{:s}: histogram of JPEG2000 values'.format(measurement))
+    ax.set_xlabel('observation time')
+    ax.set_ylabel('value')
+
+    # Include a colorbar
+    cbar = fig.colorbar(cax)
+    cbar.ax.set_ylabel('log10(fraction found)')
+    plt.legend(framealpha=0.5)
+    plt.grid('on', linestyle=':')
+    plt.show()
+
+    # Plot the fraction of low-intensity pixels
+    fig, ax = plt.subplots()
+    ax.xaxis_date()
+    ax.xaxis.set_major_formatter(date_format)
+    fig.autofmt_xdate()
+    for jpeg_value in range(0, low_level):
+        ax.plot(xlims, time_histogram[jpeg_value, :], label='level={:s}'.format(str(jpeg_value)))
+
+    # Set the image titles and labels
+    ax.set_title('Fractions found for low intensities'.format(measurement))
+    ax.set_xlabel('observation time')
+    ax.set_ylabel('log10(fraction found)')
+    plt.grid('on', linestyle=':')
+    plt.legend()
     plt.show()

--- a/py/create_histograms.py
+++ b/py/create_histograms.py
@@ -1,0 +1,50 @@
+#
+# Create histograms of
+#
+import os
+import glob
+import numpy as np
+import matplotlib.pyplot as plt
+import sunpy.map
+import matplotlib.dates as mdates
+
+measurements = ['304'] #, '131', '171', '193', '211', '304', '335', '1600', '1700', '4500']
+storage = os.path.expanduser('~/Data/hvp/aia_color_correction')
+
+
+for measurement in measurements:
+    print('Measurement = ' + measurement)
+    # Define the storage directory
+    storage_measurement = os.path.join(storage, measurement)
+
+    # Get an ordered list of files in the directory
+    filelist = sorted(glob.glob(storage_measurement + '/*.jp2'))
+
+    # Number of files
+    n = len(filelist)
+
+    # Storage
+    time_histogram = np.zeros((256, n))
+    x_lims = []
+    # Create a histogram
+    for i, f in enumerate(filelist):
+        print(f, i, len(filelist))
+        m = sunpy.map.Map(f)
+        x_lims.append(m.date)
+        for p in range(0, 256):
+            time_histogram[p, i] = np.log10(np.sum(m.data[:, :] == p))
+
+    xlims = mdates.date2num(x_lims)
+    cmap = plt.get_cmap('bwr')
+    cmap.set_bad(color='k', alpha=1.)
+    fig, ax = plt.subplots()
+    ax.imshow(time_histogram, origin='lower', aspect='auto', cmap=cmap,
+              extent=[xlims[0], xlims[1], 0, 255])
+    ax.xaxis_date()
+    date_format = mdates.DateFormatter('%Y-%m-%d')
+    ax.xaxis.set_major_formatter(date_format)
+    # This simply sets the x-axis data to diagonal so it fits better.
+    fig.autofmt_xdate()
+
+    plt.colorbar()
+    plt.show()

--- a/py/download_jp2_set.py
+++ b/py/download_jp2_set.py
@@ -1,0 +1,42 @@
+#
+# Download a set of jp2 files from helioviewer
+#
+import os
+import datetime
+import astropy.units as u
+from sunpy.time import parse_time
+from sunpy.net.helioviewer import HelioviewerClient
+
+cadence = 1 * u.year
+start_time = parse_time('2010/10/01')
+end_time = parse_time('2017/02/01')
+
+hv = HelioviewerClient()
+observatory = 'SDO'
+instrument = 'AIA'
+detector = 'AIA'
+measurements = ['94', '131', '171', '193', '211', '335', '1600', '1700', '4500']
+measurements = ['304']
+
+storage = os.path.expanduser('~/Data/hvp/aia_color_correction')
+if not os.path.isdir(storage):
+    os.makedirs(storage)
+
+
+for measurement in measurements:
+    # Make the storage directory
+    storage_measurement = os.path.join(storage, measurement)
+    if not os.path.isdir(storage_measurement):
+        os.makedirs(storage_measurement)
+
+    today = start_time
+    while today <= end_time:
+        # Get the next file
+        filepath = hv.download_jp2(today, observatory=observatory,
+                                   instrument=instrument, detector=detector,
+                                   measurement=measurement)
+
+        # Move the file to the storage location
+        _dummy, filename = os.path.split(filepath)
+        os.rename(filepath, os.path.join(storage_measurement, filename))
+        today += datetime.timedelta(seconds=cadence.to(u.s).value)

--- a/py/download_jp2_set.py
+++ b/py/download_jp2_set.py
@@ -7,7 +7,7 @@ import astropy.units as u
 from sunpy.time import parse_time
 from sunpy.net.helioviewer import HelioviewerClient
 
-cadence = 1 * u.year
+cadence = 28 * u.day
 start_time = parse_time('2010/10/01')
 end_time = parse_time('2017/02/01')
 
@@ -15,8 +15,8 @@ hv = HelioviewerClient()
 observatory = 'SDO'
 instrument = 'AIA'
 detector = 'AIA'
-measurements = ['94', '131', '171', '193', '211', '335', '1600', '1700', '4500']
-measurements = ['304']
+measurements = ['94', '131', '171', '193', '211', '304', '335', '1600', '1700', '4500']
+#measurements = ['193', '211', '335', '1600', '1700', '4500']
 
 storage = os.path.expanduser('~/Data/hvp/aia_color_correction')
 if not os.path.isdir(storage):


### PR DESCRIPTION
The existing version of JP2Gen is awkward when it comes to writing data from SOHO and STEREO.  In order for data to be written in to the correct output directories a variable in a file had to be changed, SSWIDL started up, and that version of that file was used.  SSWIDL then loads in all the code blocks in to that session. To write SOHO and STEREO files simultaneously would require manual changes to that file - two parallel sessions that differ in one slightly different file.

This made it difficult develop scripts what would re-start in a nice way when the machine that these scripts run on re-boot.  A lot of handholding was required.

This PR fixes that issue - the top level observatory must be specified for SOHO and STEREO.  This removes the need to manually edit files to have SOHO and STEREO processing at the same time.

Skeleton support for RHESSI is also included.  This code is included for completeness.  It is liable to change in the future now that RHESSI is in Phase F.

