### PR TITLE
TRACE processing now works with new hv_writtenby

### DIFF
--- a/idl/trace/hv_trace_prep2jp2.pro
+++ b/idl/trace/hv_trace_prep2jp2.pro
@@ -44,7 +44,8 @@ PRO HV_TRACE_PREP2JP2, header, image, overwrite=overwrite, jp2_filename = jp2_fi
           mmm: string(ext.minute, format='(I2.2)'), $
           ss: string(ext.second, format='(I2.2)'), $
           milli: string(ext.millisecond, format='(I3.3)'), $
-          details: details}
+          details: details, $
+          write_this: 'trace'}
 
   ; HV structure
   hvs = {img: image, hvsi: hvsi}


### PR DESCRIPTION
TRACE processing (from years ago) was not compatible with the changes with hv_writtenby.pro. This edit fixes that. Note that your local hv_writtenby.pro must also be updated to make TRACE processing work. The fix is simple. Add 'trace' to the `LIST` variable `supported` - see https://github.com/Helioviewer-Project/jp2gen/blob/master/idl/local/EXAMPLE_hv_writtenby.pro .