### PR TITLE
Remove passing a palette to TRACE JP2 file creation

### DIFF
--- a/idl/gen/hv_write_jp2_lwg.pro
+++ b/idl/gen/hv_write_jp2_lwg.pro
@@ -566,7 +566,7 @@ PRO HV_WRITE_JP2_LWG,file,image,write_this,bit_rate=bit_rate,n_layers=n_layers,n
         oJP2->SetData,image_new_with_transparency
         OBJ_DESTROY, oJP2
         print,' '
-        print,progname + ' created ' + file + '.jp2'
+        print,progname + ' created image with transparency: ' + file + '.jp2'
 ;
 ; Change the permissions on the file
 ;
@@ -579,6 +579,7 @@ PRO HV_WRITE_JP2_LWG,file,image,write_this,bit_rate=bit_rate,n_layers=n_layers,n
 ; No transparencey mask was passed, so just use normal IDL routines.
 ;
         if have_tag(details.details,'palette') then begin
+           print, 'Palette has been passed '
            oJP2 = OBJ_NEW('IDLffJPEG2000',file + '.jp2',/WRITE,$
                        bit_rate=bit_rate,$
                        n_layers=n_layers,$

--- a/idl/trace/hvs_trace.pro
+++ b/idl/trace/hvs_trace.pro
@@ -47,18 +47,18 @@ details = {measurement: '', $
            n_levels: 8, $
            n_layers: 8, $
            idl_bitdepth: 8, $
-           bit_rate: [8, 0.01],$
-           palette: intarr(3, 256)}
+           bit_rate: [8, 0.01]}
+;           palette: intarr(3, 256)}
 details = replicate(details, 8)
 ;
 ; The measurements used by Helioviewer
 ;
 details.measurement = ['WL', '171', '195', '284', '1216', '1550', '1600', '1700']
-colortable_measurement = [-1000, 171, 195, 284, 1216, 1550, 1600, 1700]
-for i = 0, 7 do begin
-   hv_trace_write_colortable_png, measurements=colortable_measurement[i], rgb = rgb, /nowrite
-   details[i].palette = rgb
-endfor
+;colortable_measurement = [-1000, 171, 195, 284, 1216, 1550, 1600, 1700]
+;for i = 0, 7 do begin
+;   hv_trace_write_colortable_png, measurements=colortable_measurement[i], rgb = rgb, /nowrite
+;   details[i].palette = rgb
+;endfor
 ;
 ; The measurements as used in the TRACE fits files
 ;


### PR DESCRIPTION
This means the resulting file does not have any color associated with it, and can be read without error by existing versions of SunPy. Solves #31.